### PR TITLE
Integrate Chilean pesos formatting in price components

### DIFF
--- a/src/components/dashboard/price/priceCard.component.tsx
+++ b/src/components/dashboard/price/priceCard.component.tsx
@@ -2,6 +2,7 @@ import { PriceCardProps } from "@/type";
 import { motion } from "framer-motion";
 import { FC } from "react";
 import { useMatriculaValue } from "@/hooks/useMatriculaValue";
+import { toChileanPesos } from "@/utils/toChileanPesos.util";
 
 const PriceCard: FC<PriceCardProps> = ({
   price,
@@ -54,7 +55,7 @@ const PriceCard: FC<PriceCardProps> = ({
             price.active ? "text-white" : "text-accent-medium"
           }`}
         >
-          ${price.price}{" "}
+          ${toChileanPesos(price.price)}{" "}
           <span className="text-accent-medium text-sm font-montserrat">
             {price.type}
           </span>
@@ -72,7 +73,9 @@ const PriceCard: FC<PriceCardProps> = ({
                 price.active ? "text-white" : "text-accent-medium"
               }`}
             >
-              <span className="text-2xl">${matriculaValue}</span>
+              <span className="text-2xl">
+                ${toChileanPesos(matriculaValue)}
+              </span>
               <span className="text-accent-medium text-xs ml-1">
                 pago único
               </span>

--- a/src/components/home/pricing/priceCard.component.tsx
+++ b/src/components/home/pricing/priceCard.component.tsx
@@ -1,5 +1,6 @@
 import { PriceCardComponentProps } from "@/type";
 import { fadeInUp } from "@/utils/motionEffect.util";
+import { toChileanPesos } from "@/utils/toChileanPesos.util";
 import { motion } from "framer-motion";
 import { FC } from "react";
 
@@ -43,7 +44,7 @@ const PriceCard: FC<PriceCardComponentProps> = ({
           {!showConsultButton && (
             <>
               <span className="text-2xl mr-1 mt-2">$</span>
-              {item.price}
+              {toChileanPesos(item.price)}
               <span className="text-lg text-accent-medium self-end mb-2">
                 /{item.name}
               </span>
@@ -57,8 +58,8 @@ const PriceCard: FC<PriceCardComponentProps> = ({
         </p>
       </div>
       <ul className="font-montserrat text-accent-light space-y-4 mb-8 text-sm">
-        {item.characteristics.map((char: string) => (
-          <li key={char} className="flex items-start">
+        {item.characteristics.map((char: string, index) => (
+          <li key={`${char}_${index}`} className="flex items-start">
             <span className="text-primary mr-2 mt-0.5 flex-shrink-0">
               <svg
                 width="16"

--- a/src/components/home/pricing/pricing.component.tsx
+++ b/src/components/home/pricing/pricing.component.tsx
@@ -7,6 +7,7 @@ import { motion } from "framer-motion";
 import { FC, useEffect, useState, useMemo } from "react";
 import PriceCard from "./priceCard.component";
 import { useMatriculaValue } from "@/hooks/useMatriculaValue";
+import { toChileanPesos } from "@/utils/toChileanPesos.util";
 
 const PricingComponent: FC = () => {
   const [prices, setPrices] = useState<IPriceData[]>([]);
@@ -106,7 +107,7 @@ const PricingComponent: FC = () => {
                     $
                   </span>
                   <span className="text-primary font-bebas text-4xl">
-                    {matriculaValue}
+                    {toChileanPesos(matriculaValue)}
                   </span>
                   <span className="text-accent-medium text-xs self-end mb-1 ml-1">
                     (pago único)


### PR DESCRIPTION
Implement a utility to format prices in Chilean pesos across PriceCard and PricingComponent for consistent currency representation.